### PR TITLE
Error 14 en highcharts: Usamos parsefloat en JS para evitar inconsistencias en json_encode

### DIFF
--- a/public/js/custom-charts.js
+++ b/public/js/custom-charts.js
@@ -1,10 +1,8 @@
 $(function () {
-	console.log(javascript);
+	//console.log(javascript);
 	var devices = javascript.points;
 	var deviceNames = Object.keys(devices);
-	console.log(devices, 'devices');
-	console.log(deviceNames, 'deviceNames');
-
+	
 	// Entramos en cada uno de los devices dentro de device.
 	for (var i = 0; i < deviceNames.length; i++) {
 		var chartData = {};
@@ -12,25 +10,27 @@ $(function () {
 		var sensors = devices[deviceName];
 		var series = [];
 		var sensorNames = Object.keys(sensors);
-		console.log(sensorNames);
 		// Entramos en cada sensor del dispositivo
 		for(x = 0; x < sensorNames.length; x++){
 			var sensorName = sensorNames[x];
-			console.log(sensorName);
 			// Generamos una serie para cada sensor 
+			var serie = sensors[sensorName];
+			var parsed = serie.map(function(element){
+				return [element[0], parseFloat(element[1])];
+			});
 			series.push({
 				name: sensorName,
-				data: sensors[sensorName]
+				data: parsed
 			});
 		}
 		
-		console.log(series);
 		// Asignamos series para el highchart
 		chartData.series = series;
 
 		// Le damos un title al highchart
 		chartData.title = 'Device: ' + deviceNames[i];
-
+		console.log(chartData);
+		
 		// Ejecutamos la función sobre el selector jquery
 		printChart($('#' + deviceName + '-chart'), chartData);
 	};


### PR DESCRIPTION
Parece que PHP tiene alguna inconsistencia a la hora de codificar enteros con json_encode.

http://stackoverflow.com/questions/1390983/php-json-encode-encoding-numbers-as-strings

He hecho un cambio al JS para usar `parsefloat()` en las series antes de pasarlas a highcharts.

He aprovechado para quitar mucho `console.log` que ya aburría.

Si te aceptas este pull request se aplicaran los cambios en tu fork y podrás hacer `git pull` desde tu servidor para ver si así solucionamos el error.
